### PR TITLE
feat(template): implement multi-template scaffolding

### DIFF
--- a/cli-tool/.idx/dev.nix
+++ b/cli-tool/.idx/dev.nix
@@ -1,0 +1,23 @@
+{ pkgs, ... }: {
+  channel = "stable-24.11";
+
+  packages = [
+    pkgs.go
+    pkgs.gopls
+    pkgs.delve
+    pkgs.golangci-lint
+    pkgs.git
+  ];
+
+  idx = {
+    extensions = [
+      "golang.go",
+      "GitHub.vscode-pull-request-github",
+    ];
+    workspace.onCreate.installAndTidy = ''
+      go mod download
+      go mod tidy
+    '';
+    previews.enable = false; # No web preview needed for a CLI tool
+  };
+}

--- a/cli-tool/README.md
+++ b/cli-tool/README.md
@@ -1,0 +1,27 @@
+# Go CLI Tool Template
+
+This template provides a starter kit for building a command-line interface (CLI) application in Go using the popular [Cobra](https://cobra.dev/) library.
+
+When you create a project from this template, the Go module path will be automatically set to the value you provided.
+
+## Features
+
+- **Structure:** Follows the standard Cobra layout (`main.go` and a `cmd/` directory).
+- **Example Command:** Includes a `hello` subcommand to demonstrate basic functionality.
+- **Flag Support:** The `hello` command includes a `--name` flag to show how to handle user input.
+
+## How to Use
+
+1.  **Build the binary:**
+    ```bash
+    go build -o my-cli .
+    ```
+
+2.  **Run the command:**
+    ```bash
+    # Run the default hello command
+    ./my-cli hello
+
+    # Run with the name flag
+    ./my-cli hello --name "Alice"
+    ```

--- a/cli-tool/cmd/root.go
+++ b/cli-tool/cmd/root.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var name string
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "my-cli",
+	Short: "A brief description of your application",
+	Long: `A longer description that spans multiple lines and likely contains
+examples and usage of using your application.`,
+}
+
+// helloCmd represents the hello command
+var helloCmd = &cobra.Command{
+	Use:   "hello",
+	Short: "Prints a friendly greeting.",
+	Long:  `Prints 'Hello, World!' or a personalized greeting if the --name flag is provided.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if name != "" {
+			fmt.Printf("Hello, %s!\n", name)
+		} else {
+			fmt.Println("Hello, World!")
+		}
+	},
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	// Add the hello subcommand to the root command.
+	rootCmd.AddCommand(helloCmd)
+
+	// Add a persistent --name flag to the hello command.
+	helloCmd.Flags().StringVarP(&name, "name", "n", "", "Name to greet (optional)")
+}

--- a/cli-tool/go.mod
+++ b/cli-tool/go.mod
@@ -1,0 +1,10 @@
+module your-module-name
+
+go 1.24
+
+require github.com/spf13/cobra v1.8.1
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/cli-tool/main.go
+++ b/cli-tool/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "your-module-name/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/idx-template.json
+++ b/idx-template.json
@@ -1,12 +1,12 @@
 {
-  "name": "Go Backend Starter Kit",
+  "name": "Go Starter Templates",
   "description": "Bootstrap a new Go backend project, from a simple CLI to a cloud-native API.",
   "categories": [
     "Backend",
     "API",
     "CLI"
   ],
-  "icon": "https://www.gstatic.com/monospace/231115/logo_go.svg",
+  "icon": ".idx/icon.png",
   "publisher": "Context Vibes",
   "params": [
     {
@@ -18,6 +18,14 @@
         "cloud-run-api": "Cloud Run API Server (Hello World)",
         "cli-tool": "Command-Line Application (Cobra)"
       },
+      "required": true
+    },
+    {
+      "id": "goModulePath",
+      "name": "Go Module Path",
+      "description": "The Go module path for your new project (e.g., github.com/your-name/my-project).",
+      "type": "string",
+      "default": "github.com/my-org/my-app",
       "required": true
     }
   ]

--- a/idx-template.nix
+++ b/idx-template.nix
@@ -7,56 +7,62 @@
   # This defines an input argument named 'environment'. Its value is provided by the
   # templating system based on the user's choice for the 'projectType' parameter
   # in 'template.json'.
-  # The '? "cloud-run-api"' sets a default value. This is a safety measure ensuring
-  # the template has a fallback if the input is not provided for any reason.
-  # This value should match the 'default' in 'template.json'.
   environment ? "cloud-run-api",
+  # This captures the 'goModulePath' parameter from 'template.json'.
+  goModulePath ? "github.com/my-org/my-app",
   ...
 }: {
-  # We only need a basic shell for this script, so we request 'bash' from Nixpkgs.
-  packages = [ pkgs.bash ];
+  # We need bash and gnsed (GNU sed) for our script to ensure compatibility.
+  packages = [ pkgs.bash pkgs.gnsed ];
 
   # The 'bootstrap' attribute contains the shell script that runs to create the workspace.
   bootstrap = ''
     # 'set -e' causes the script to exit immediately if any command fails.
     # 'set -x' prints each command to the log before it is executed.
-    # This combination is a best practice for robust and debuggable shell scripts.
     set -ex
 
     # --- Logging and Verification ---
-    # These echo statements provide clear output in the build logs, which is
-    # essential for understanding and debugging the template creation process.
-    echo "Bootstrapping selected project type: ${environment}"
-    echo "Source directory to copy: ${./.}/${environment}"
+    echo "Bootstrapping selected project type: ''${environment}''"
+    echo "Source directory to copy: ''${./.}/''${environment}''"
     echo "Target workspace name (from env): $WS_NAME"
+    echo "Go Module Path to set: ''${goModulePath}''"
     echo "Final output directory (from Nix): $out"
 
     # --- Critical Pre-flight Check ---
-    # This is the most important safety feature. It verifies that a source directory
-    # corresponding to the selected 'environment' actually exists before trying to copy it.
-    # This prevents cryptic errors if the template is misconfigured.
-    if [ ! -d "${./.}/${environment}" ]; then
-      echo "CRITICAL ERROR: Source directory '${./.}/${environment}' does not exist for the selected project type."
+    if [ ! -d "''${./.}/''${environment}''" ]; then
+      echo "CRITICAL ERROR: Source directory '''${./.}/''${environment}''' does not exist for the selected project type."
       exit 1
     fi
 
     # --- Scaffolding Logic ---
-    # 1. Copy the source files from the selected template variant directory into a
-    #    new directory named after the workspace ($WS_NAME is provided by the environment).
-    cp -rf "${./.}/${environment}" "$WS_NAME"
+    # 1. Copy the source files into a temporary directory.
+    TMP_DIR=$(mktemp -d)
+    cp -rf "''${./.}/''${environment}"/* "$TMP_DIR"
 
-    # 2. Recursively add write permissions to all copied files and directories.
-    #    This is a crucial step because files managed by Nix can be read-only by default.
-    #    This ensures the user can edit the files in their new workspace.
+    # 2. Perform the automated module path replacement.
+    # We use a placeholder that is unlikely to conflict with user code.
+    PLACEHOLDER="your-module-name"
+    echo "Replacing placeholder '$$PLACEHOLDER' with '$$goModulePath'..."
+    # Find all .go files, go.mod, and the README, then run sed on them.
+    # Using -print0 and xargs -0 is the safest way to handle filenames.
+    find "$TMP_DIR" -type f \( -name "*.go" -o -name "go.mod" -o -name "README.md" \) -print0 | xargs -0 sed -i "s|$$PLACEHOLDER|''${goModulePath}''|g"
+
+    # 3. Move the prepared content into the final destination directory.
+    # First, create a directory named after the workspace.
+    mkdir -p "$WS_NAME"
+    # Then, move the modified files from the temp directory into it.
+    mv "$TMP_DIR"/* "$WS_NAME"
+    # Clean up the temp directory.
+    rm -rf "$TMP_DIR"
+
+    # 4. Recursively add write permissions to all copied files and directories.
     chmod -R +w "$WS_NAME"
 
-    # 3. Move the prepared workspace content into the final destination directory ($out).
-    #    The Nix build process requires that the final result of the script be placed
-    #    in the location specified by the '$out' environment variable.
+    # 5. Move the final workspace content to the required output directory.
     mv "$WS_NAME" "$out"
 
     # --- Final Confirmation ---
-    echo "Bootstrapping complete for project type: ${environment}."
+    echo "Bootstrapping complete for project type: ''${environment}''."
     echo "Workspace content is now in: $out"
   '';
 }


### PR DESCRIPTION
Implement a multi-template architecture for the repository.

This commit introduces:
- A new 'cli-tool' template based on the Cobra library.
- An interactive prompt to the 'export_code.sh' script, allowing users to select which product to export.
- An automated module path replacement system in the templating engine ('idx-template.nix'), which prompts the user for their desired module path and configures the project automatically.
